### PR TITLE
Redo error code responses

### DIFF
--- a/canteven-snap.cabal
+++ b/canteven-snap.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-snap
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            A more or less random collection of Snap shorthand and utilities that make webservice programming easier.
 -- description:
 homepage:            https://github.com/SumAll/canteven-snap


### PR DESCRIPTION
Fail fast for all of the "return with" functions (notFound, etc). Add
`accepted` and `internalServerError`. Finally, force the user to give a
reason for the failure (no more "404...that's it").